### PR TITLE
Use documentRoot as zip name for ionic upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.swp
 coverage/
 .vscode/
+.idea/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -13,7 +13,7 @@ var shelljs = require('shelljs');
 var log = require('./logging').logger;
 var chalk = require('chalk');
 
-var TEMP_FILENAME = 'www.zip';
+var TEMP_FILENAME = '';
 var Upload = module.exports;
 
 Upload.doUpload = function doUpload(appDirectory, jar, note, deploy) {
@@ -29,6 +29,8 @@ Upload.doUpload = function doUpload(appDirectory, jar, note, deploy) {
   var documentRoot = project.get('documentRoot') || 'www';
   var indexPath = path.join(appDirectory, documentRoot, 'index.html');
   var upload;
+
+  TEMP_FILENAME = documentRoot + '.zip';
   try {
     return Upload.addCacheBusters(indexPath)
     .then(function() {


### PR DESCRIPTION
Hi, currently I'm using Ionic Deploy to upload snapshots of my app, but I'm using a different folder as documentRoot for my src files ("dist" vs "www"). When I run "ionic upload --env" with "dist" as documentRoot (defined on ionic.config.json) it creates a "dist.zip" file but at the moment to upload the app upload.js is looking for "www.zip" (TEMP_FILENAME). 